### PR TITLE
Remove xcode dependency. Only xcode command line tools are needed.

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -4,7 +4,6 @@ class AwsSsoCli < Formula
   url "__URL__"
   sha256 "__SHA256__"
 
-  depends_on :xcode
   depends_on "go" => [:build, "1.17.0"]
 
   def install


### PR DESCRIPTION
xcode as a dependency means the full xcode install. This is unecessary and currently means users needed to install xcode via app store before installing aws-sso via homebrew.

xcode command line tools is a requirement for homebrew so we can assume that it is already installed.